### PR TITLE
fix: footer 컴포넌트 반응형 디자인 고려에 따른 웹 화면 수정

### DIFF
--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -6,7 +6,7 @@ const meta: Meta<typeof Footer> = {
   component: Footer,
   decorators: [
     (Story) => (
-      <div className='bg-[#FAFAFA] w-[1920px] pt-[20px]'>
+      <div className='bg-[#FAFAFA] w-full pt-5'>
         <Story />
       </div>
     ),

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -4,30 +4,24 @@ import { LogoIcon } from '../../assets';
 
 const Footer: React.FC = () => {
     return (
-        <footer className='flex w-[1520px] pb-[56px] flex-col items-start gap-[24px] mx-auto'>
-            <div className='h-0 self-stretch'>
-                <svg xmlns="http://www.w3.org/2000/svg" width="1521" height="2" viewBox="0 0 1521 2" fill="none">
-                    <path d="M0.904297 0.582275H1520.9" stroke="#F0F0F0" strokeWidth="1" />
-                </svg>
-            </div>
-            <div className='flex justify-between items-center self-stretch'>
+        <footer className='flex w-full pt-6 pb-14 flex-col items-start gap-6 border-t border-[#F0F0F0]'>
+            <div className='w-[1200px] mx-auto flex justify-between items-center self-stretch'>
                 {/* 좌측: 로고 + 링크 */}
-                <div className='flex w-[390px] items-center gap-[8px]'>
+                <div className='flex w-[390px] items-center gap-2'>
                     <LogoIcon className="w-8 h-8" />
                     <div className='flex items-center'>
-                        <button className='flex h-[44px] py-0 px-[24px] justify-center items-center gap-[8px] text-[#949494] font-pretendard text-[16px] font-medium leading-[140%] hover:underline hover:text-[#707070]'>이용약관</button>
+                        <button className='flex h-11 px-6 justify-center items-center gap-2 text-[#949494] font-pretendard text-base font-medium leading-[140%] hover:underline hover:text-[#707070]'>이용약관</button>
+                        {/* divider */}
                         <div className='w-0 h-[20.308px]'>
                             <svg xmlns="http://www.w3.org/2000/svg" width="2" height="21" viewBox="0 0 2 21" fill="none">
-                                <path d="M0.904297 0.428467V20.7361" stroke="#F0F0F0" strokeWidth="1" />
+                                <path d="M0.691406 0.430176V20.7378" stroke="#F0F0F0" strokeWidth="1" />
                             </svg>
                         </div>
-                        <button className='flex h-[44px] py-0 px-[24px] justify-center items-center gap-[8px] text-[#949494] font-pretendard text-[16px] font-medium leading-[140%] hover:underline hover:text-[#707070]'>개인정보처리방침</button>
+                        <button className='flex h-11 px-6 justify-center items-center gap-2 text-[#949494] font-pretendard text-base font-medium leading-[140%] hover:underline hover:text-[#707070]'>개인정보처리방침</button>
                     </div>
                 </div>
                 {/* 우측: 카피라이트 */}
-                <div className='text-[#CCC] text-right font-montserrat text-[16px] font-medium'>
-                    Copyright © PACKUP Co. All rights reserved
-                </div>
+                <div className='text-[#CCC] text-right font-montserrat text-base font-medium leading-[normal]'>Copyright © PACKUP Co. All rights reserved</div>
             </div>
         </footer>
     );

--- a/src/components/Header/Header.stories.tsx
+++ b/src/components/Header/Header.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Header from '.';
+
+const meta: Meta<typeof Header> = {
+  title: 'Components/Header',
+  component: Header,
+  decorators: [
+    (Story) => (
+      <div className='bg-[#FAFAFA] w-[1920px] pb-[20px]'>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    // props 없음
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Header>;
+
+export const Default: Story = {
+  render: (args) => <Header {...args} />,
+};

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+// 임시 아이콘
+import { LogoIcon } from '../../assets';
+
+const Header: React.FC = () => {
+    return (
+        <header className='flex w-[1920px] h-[84px] py-[8px] px-[200px] justify-between items-center shrink-0 border border-[#F0F0F0] bg-white'>
+            {/* 좌측: 로고 */}
+            <a href="/" className='flex items-center gap-[8px]'>
+                <LogoIcon className="w-8 h-8" />
+                <span className='text-black font-montserrat text-[18px] font-semibold uppercase'>Pack up</span>
+            </a>
+            {/* 우측: 사용자 인터랙션 영역 */}
+            <div className='flex items-center gap-[8px]'>
+                <button className='flex w-11 h-11 p-1.5 justify-center items-center'>
+                    <div className='w-8 h-8 shrink-0 aspect-square'>
+                        {/* 추가 예정 */}
+                    </div>
+                </button>
+                {/* 마이페이지 + 로그인 */}
+                <div className='flex items-center'>
+                    <button className='flex h-11 py-0 px-6 justify-center items-center gap-2 text-[rgba(0,0,0,0.72)] font-pretendard text-base font-medium leading-[140%] hover:text-[#411BFF]'>마이페이지</button>
+                    {/* 로그인 버튼 디자인 문의 답변 확인 필요함 */}
+                    <button className='flex h-11 py-0 px-6 justify-center items-center gap-2 text-[rgba(0,0,0,0.72)] font-pretendard text-base font-medium leading-[140%] hover:text-[#411BFF]'>로그인</button>
+                </div>
+            </div>
+        </header>
+    );
+};
+
+export default Header;


### PR DESCRIPTION
## Overview

- footer 컴포넌트 반응형 디자인 고려에 따른 웹 화면(1440px+) 수정


## 🔎 작업 내용

- [x] 푸터 영역 화면 가로 꽉 채우게 변경(border 길이 = 화면 길이)
- [x] 푸터 컨텐츠 너비는 웹 화면(1440px+) 기준 1200px, 가운데 정렬
- [x] 아직 모바일, 태블릿 구현 안 된 상태입니다!(디자인 미완)

## 📷 이미지 첨부
<img width="1204" height="123" alt="image" src="https://github.com/user-attachments/assets/393fb527-08df-419b-add6-b19156c403da" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new header component with navigation buttons and logo.
  * Introduced Storybook stories for the header component.

* **Style**
  * Updated footer layout for improved responsiveness and consistency.
  * Refined footer button styles and spacing.
  * Adjusted Storybook footer story container for better layout preview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->