### PR TITLE
feat: 대시보드에 모달 추가해서 새 템플릿 버튼에 연결

### DIFF
--- a/src/pages/DashboardPage/components/AddTemplateTypeModal.tsx
+++ b/src/pages/DashboardPage/components/AddTemplateTypeModal.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import Button from "../../../components/Button";
+import { CloseIcon } from "../../../assets";
+
+type Props = {
+    isOpen: boolean;
+    onClose: () => void;
+    onPick: (type: "new" | "preset") => void;
+};
+
+const ensureRoot = () => {
+    if (typeof document === "undefined") return null;
+    let el = document.getElementById("modal-root");
+    if (!el) {
+        el = document.createElement("div");
+        el.id = "modal-root";
+        document.body.appendChild(el);
+    }
+    return el;
+};
+
+export default function AddTemplateTypeModal({ isOpen, onClose, onPick }: Props) {
+    const root = ensureRoot();
+    const [picked, setPicked] = useState<"new" | "preset" | null>("new");
+
+    useEffect(() => {
+        if (!isOpen) return;
+        const prev = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
+        const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+        window.addEventListener("keydown", onKey);
+        return () => {
+            window.removeEventListener("keydown", onKey);
+            document.body.style.overflow = prev;
+        };
+    }, [isOpen, onClose]);
+
+    // 모달 열릴 때 선택 초기화
+    useEffect(() => {
+        if (isOpen) setPicked("new");
+    }, [isOpen]);
+
+    if (!isOpen || !root) return null;
+
+    return createPortal(
+        <div className="fixed inset-0 z-[9998] flex items-center justify-center">
+            {/* dim */}
+            <button aria-label="닫기" onClick={onClose} className="absolute inset-0 bg-black/50" />
+            {/* 모달창 */}
+            <div role="dialog" aria-modal="true" className="z-[9999] inline-flex p-[16px_24px_24px_24px] flex-col justify-center items-center gap-4 rounded-[12px] bg-white shadow-[0_0_16px_0_rgba(0,0,0,0.02)]">
+                {/* header */}
+                <div className="flex h-11 justify-between items-center self-stretch">
+                    <div className="w-11 h-11"></div>
+                    <h2 className="text-[#141414] text-center font-pretendard text-[18px] font-semibold leading-normal">생성할 템플릿 유형을 선택하세요.</h2>
+                    <div className="flex h-[44px] p-[10px_0_10px_20px] justify-end items-center">
+                        <button onClick={onClose} className="w-6 h-6 cursor-pointer"><CloseIcon className="w-6 h-6" /></button>
+                    </div>
+                </div>
+                {/* contents */}
+                <div className="flex flex-col items-start gap-[32px] self-stretch">
+                    {/* steps */}
+                    <div className="flex items-start gap-4">
+                        <button onClick={() => setPicked("new")}
+                        className={`flex w-[204px] p-4 flex-col items-start gap-4 rounded-2xl border-2 focus:outline-none focus-visible:outline-none ${picked === "new" ? "border-[#A593FF] bg-[#F6F4FF]" : "border-[#F0F0F0]"}`}>
+                            <div className="w-full flex flex-col items-start gap-2 self-stretch text-left">
+                                <h3 className="text-[rgba(0,0,0,0.90)] font-pretendard text-[20px] font-semibold leading-normal">신규 템플릿</h3>
+                                <p className="mb-6 self-stretch text-[rgba(0,0,0,0.64)] font-pretendard text-base font-medium leading-normal">빈 캔버스에서 처음부터 템플릿을 생성합니다.</p>
+                            </div>
+                            <div className="flex items-center justify-center h-[200px] self-stretch rounded-[16px] bg-[rgba(0,0,0,0.04)]">이미지 추가 필요</div>
+                        </button>
+                        <button onClick={() => setPicked("preset")}
+                        className={`flex w-[204px] p-4 flex-col items-start gap-4 rounded-2xl border-2 focus:outline-none focus-visible:outline-none ${picked === "preset" ? "border-[#A593FF] bg-[#F6F4FF]" : "border-[#F0F0F0]"}`}>
+                            <div className="w-full flex flex-col items-start gap-2 self-stretch text-left">
+                                <h3 className="text-[rgba(0,0,0,0.90)] font-pretendard text-[20px] font-semibold leading-normal">간편 템플릿</h3>
+                                <p className="self-stretch text-[rgba(0,0,0,0.64)] font-pretendard text-base font-medium leading-normal">스텝과 준비물, 상세 내용이 입력된 할일 템플릿을 선택해 불러옵니다.</p>
+                            </div>
+                            <div className="flex items-center justify-center h-[200px] self-stretch rounded-[16px] bg-[rgba(0,0,0,0.04)]">이미지 추가 필요</div>
+                        </button>
+                    </div>
+                    {/* actions */}
+                    <div className="flex items-center gap-4 self-stretch">
+                        <Button variant="line" onClick={onClose} className="flex-1 h-[50px]">닫기</Button>
+                        <Button disabled={!picked} onClick={() => { if (picked) onPick(picked); }} className="flex-1 h-[50px]">선택</Button>
+                    </div>
+                </div>
+            </div>
+        </div>,
+        root
+    );
+}

--- a/src/pages/DashboardPage/components/PresetSetModal.tsx
+++ b/src/pages/DashboardPage/components/PresetSetModal.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import Button from "../../../components/Button";
+import { CloseIcon } from "../../../assets";
+
+type Props = {
+    isOpen: boolean;
+    onClose: () => void;
+    onConfirm: (setId: string) => void;
+};
+
+const ensureRoot = () => {
+    if (typeof document === "undefined") return null;
+    let el = document.getElementById("modal-root");
+    if (!el) {
+        el = document.createElement("div");
+        el.id = "modal-root";
+        document.body.appendChild(el);
+    }
+    return el;
+};
+
+// 더미 데이터 (탭 3개)
+const PRESETS = {
+    office: [
+        { id: "office-1", title: "회의 준비", desc: "필요 문서/장비를 빠짐없이 점검해요" },
+        { id: "office-2", title: "업무 점검", desc: "오늘 해야할 체크리스트를 한 번에" },
+        { id: "office-3", title: "출근 준비", desc: "바쁜 아침에도 빠짐 없는 준비" },
+    ],
+    daily: [
+        { id: "daily-1", title: "장보기", desc: "카테고리별 장보기 추천 묶음" },
+        { id: "daily-2", title: "이사 준비", desc: "체크 항목이 많은 이사 체크리스트" },
+        { id: "daily-3", title: "반려동물", desc: "산책/미용/병원 방문 미리 체크" },
+    ],
+    travel: [
+        { id: "travel-1", title: "여행 준비", desc: "바로 캐리어들고 떠날 수 있는 \n완벽한 체크리스트" },
+        { id: "travel-2", title: "해외여행", desc: "여권/환전/USIM 등 필수 준비" },
+        { id: "travel-3", title: "캠핑", desc: "캠핑/백패킹 필수 장비 묶음" },
+    ],
+} as const;
+
+type TabKey = keyof typeof PRESETS;
+
+export default function PresetSetModal({ isOpen, onClose, onConfirm }: Props) {
+    const root = ensureRoot();
+    const [tab, setTab] = useState<TabKey>("office");
+    const [selected, setSelected] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!isOpen) return;
+        const prev = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
+        const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+        window.addEventListener("keydown", onKey);
+        return () => {
+            window.removeEventListener("keydown", onKey);
+            document.body.style.overflow = prev;
+        };
+    }, [isOpen, onClose]);
+
+    // 열릴 때 초기화
+    useEffect(() => {
+        if (isOpen) {
+            setTab("office");
+            setSelected(PRESETS["office"][0].id);
+        }
+    }, [isOpen]);
+
+    const list = PRESETS[tab];
+    const canConfirm = !!selected;
+
+    if (!isOpen || !root) return null;
+
+    return createPortal(
+        <div className="fixed inset-0 z-[9998] flex items-center justify-center">
+            {/* dim */}
+            <button aria-label="닫기" onClick={onClose} className="absolute inset-0 bg-black/50" />
+            {/* 모달 카드 */}
+            <div
+                role="dialog"
+                aria-modal="true"
+                className="z-[9999] inline-flex flex-col gap-8 rounded-[12px] bg-white p-[16px_24px_24px_24px] shadow-[0_0_16px_0_rgba(0,0,0,0.02)]"
+            >
+                {/* contents */}
+                <div className="flex flex-col items-center gap-4 self-stretch">
+                    {/* header */}
+                    <div className="flex h-11 items-center justify-between self-stretch">
+                        <div className="h-11 w-11" />
+                        <h2 className="font-pretendard text-[18px] font-semibold leading-normal text-[#141414]">
+                            추천 템플릿 세트를 선택하세요.
+                        </h2>
+                        <div className="flex h-[44px] items-center justify-end p-[10px_0_10px_20px]">
+                            <button onClick={onClose} className="h-6 w-6 cursor-pointer">
+                                <CloseIcon className="h-6 w-6" />
+                            </button>
+                        </div>
+                    </div>
+                    {/* 카테고리 탭 */}
+                    <div className="flex w-[343px] items-center gap-4">
+                        {([
+                            { k: "office", label: "업무" },
+                            { k: "daily", label: "생활" },
+                            { k: "travel", label: "여행" },
+                        ] as { k: TabKey; label: string }[]).map(({ k, label }) => {
+                            const active = tab === k;
+                            return (
+                                <Button
+                                    key={k}
+                                    aria-selected={active}
+                                    onClick={() => {
+                                        setTab(k);
+                                        setSelected(PRESETS[k]?.[0]?.id ?? null);
+                                    }}
+                                    variant={active ? "fill" : "line"}
+                                    className={`h-[38px] p-0 text-[16px] font-pretendard ${
+                                        active ? "bg-[#5736FF]" : ""
+                                    }`}
+                                >
+                                    {label}
+                                </Button>
+                            );
+                        })}
+                    </div>
+                    {/* 템플릿 */}
+                    <div className="grid grid-cols-3 gap-4">
+                        {list.map((card) => {
+                            const active = selected === card.id;
+                            return (
+                                <button
+                                    key={card.id}
+                                    onClick={() => setSelected(card.id)}
+                                    className={`flex flex-col items-start gap-2 p-[16px] pr-[16px] pb-[32px] pl-[16px] rounded-[16px] border-2 bg-white shadow-[0_0_16px_0_rgba(0,0,0,0.02)] ${
+                                    active
+                                        ? "border-[#A593FF]"
+                                        : "border-[#F0F0F0]"
+                                    }`}
+                                >
+                                    <div className="w-[240px] h-[240px] rounded-[16px] bg-[rgba(0,0,0,0.20)]" />
+                                    <div className="flex flex-col items-start self-stretch text-left">
+                                        <div className="flex w-[240px] h-[38px] items-center gap-2 text-[rgba(0,0,0,0.90)] font-pretendard text-[18px] font-semibold leading-none">{card.title}</div>
+                                        <div className="whitespace-pre-line self-stretch text-[rgba(0,0,0,0.64)] font-pretendard text-[16px] font-medium leading-none">{card.desc}</div>
+                                    </div>
+                                </button>
+                            );
+                        })}
+                    </div>
+                </div>
+                {/* actions */}
+                <div className="flex justify-center items-center gap-4 self-stretch">
+                    <Button onClick={onClose} className="w-[200px] h-[50px]" variant="line">닫기</Button>
+                    <Button disabled={!canConfirm} onClick={() => selected && onConfirm(selected)} className="w-[200px] h-[50px]">선택</Button>
+                </div>
+            </div>
+        </div>,
+        root
+    );
+}

--- a/src/pages/DashboardPage/index.tsx
+++ b/src/pages/DashboardPage/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+// import { useNavigate } from "react-router-dom";
 import Header from "../../components/Header";
 import Button from "../../components/Button";
 import { AddIcon } from "../../assets";
@@ -8,6 +9,8 @@ import TemplateGrid from "./components/TemplateGrid";
 import EmptyState from "./components/EmptyState";
 import Footer from "../../components/Footer";
 import type { TemplateListItem } from "../../stores/templateListStore";
+import AddTemplateTypeModal from "./components/AddTemplateTypeModal";
+import PresetSetModal from "./components/PresetSetModal";
 
 // API 응답 템플릿 타입 정의
 interface ApiTemplate {
@@ -81,42 +84,10 @@ const DUMMY_TEMPLATES: TemplateListItem[] = [
     isBookmarked: true,
     thumbnail: "https://core-cdn-fe.toss.im/image/optimize/?src=https://blog-cdn.tosspayments.com/wp-content/uploads/2021/08/28011146/semo9.png?&w=3840&q=75"
     },
-    {
-    templateNo: 7,
-    templateNm: "청소하기",
-    categoryNm: "생활",
-    regDt: "2025-07-25T17:00:00Z",
-    updDt: "2025-07-25T17:00:00Z",
-    thumbnail: "https://core-cdn-fe.toss.im/image/optimize/?src=https://blog-cdn.tosspayments.com/wp-content/uploads/2021/08/28011146/semo9.png?&w=3840&q=75"
-    },
-    {
-    templateNo: 8,
-    templateNm: "장보기 리스트",
-    categoryNm: "생활",
-    regDt: "2025-07-24T16:30:00Z",
-    updDt: "2025-07-24T16:30:00Z",
-    thumbnail: "https://core-cdn-fe.toss.im/image/optimize/?src=https://blog-cdn.tosspayments.com/wp-content/uploads/2021/08/28011146/semo9.png?&w=3840&q=75"
-    },
-    {
-    templateNo: 9,
-    templateNm: "운동 루틴",
-    categoryNm: "생활",
-    regDt: "2025-07-23T19:10:00Z",
-    updDt: "2025-07-23T19:10:00Z",
-    isBookmarked: true,
-    thumbnail: "https://core-cdn-fe.toss.im/image/optimize/?src=https://blog-cdn.tosspayments.com/wp-content/uploads/2021/08/28011146/semo9.png?&w=3840&q=75"
-    },
-    {
-    templateNo: 10,
-    templateNm: "회사 행사 준비",
-    categoryNm: "업무",
-    regDt: "2025-07-22T11:00:00Z",
-    updDt: "2025-07-22T12:00:00Z",
-    thumbnail: "https://core-cdn-fe.toss.im/image/optimize/?src=https://blog-cdn.tosspayments.com/wp-content/uploads/2021/08/28011146/semo9.png?&w=3840&q=75"
-    },
 ];
 
 const DashboardPage = () => {
+    // const navigate = useNavigate();
     // 선택된 카테고리 상태
     const [selectedCategory, setSelectedCategory] = useState("전체");
     // 정렬 상태
@@ -141,6 +112,10 @@ const DashboardPage = () => {
     const [currentPage, setCurrentPage] = useState(1);
     // 더 가져올 데이터가 있는지 여부
     const [hasMore, setHasMore] = useState(true);
+
+    // 새 템플릿 버튼 클릭 시 뜨는 모달 상태
+    const [isTypeOpen, setIsTypeOpen] = useState(false);
+    const [isPresetOpen, setIsPresetOpen] = useState(false);
 
     // onAlignChange: (option: string) => void;
     const handleAlignChange = (option: string) => {
@@ -312,7 +287,8 @@ const DashboardPage = () => {
                 <div className="pt-[124px] mx-auto flex w-[1200px] justify-between items-center">
                     <div className="flex items-center gap-[31px]">
                         <h2 className="text-[#141414] text-center font-pretendard text-[26px] font-bold leading-normal">내 템플릿 목록</h2>
-                        <Button className="w-[200px] h-11">
+                        {/* 새 템플릿 버튼 -> 1단계 모달 오픈 */}
+                        <Button onClick={() => setIsTypeOpen(true)} className="w-[200px] h-11">
                             <AddIcon className="w-[18px] h-[18px]" />
                             <span className="text-white text-center font-pretendard text-[16px] font-medium leading-normal">새 템플릿</span>
                         </Button>
@@ -350,6 +326,30 @@ const DashboardPage = () => {
                 </section>
             </div>
             <Footer />
+
+            {/* 모달들 (포털로 최상단 렌더) */}
+            <AddTemplateTypeModal
+                isOpen={isTypeOpen}
+                onClose={() => setIsTypeOpen(false)}
+                onPick={(type) => {
+                    if (type === "new") {
+                        setIsTypeOpen(false);
+                        // TODO: navigate 사용해서 신규 템플릿 편집 화면으로 이동
+                    } else {
+                        setIsTypeOpen(false);
+                        setIsPresetOpen(true);
+                    }
+                }}
+            />
+            <PresetSetModal
+                isOpen={isPresetOpen}
+                onClose={() => setIsPresetOpen(false)}
+                onConfirm={(setId) => {
+                    setIsPresetOpen(false);
+                    console.log(setId); // 린트 에러 방지를 위해 임시로 넣어둠
+                    // TODO: navigate 사용해서 간편 템플릿 편집 화면으로 이동
+                }}
+            />
         </div>
     );
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a modal to choose template type (신규 템플릿 or 간편 템플릿) with keyboard support and ESC-to-close.
  - Introduced a preset selection modal with categorized tabs (업무/일상/여행), card-style presets, and confirm/close actions.
  - Updated the create flow: clicking “새 템플릿” opens the type chooser; selecting 간편 템플릿 leads to preset selection.
  - Improved accessibility with proper dialog roles, focus handling cues, and scroll locking while modals are open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->